### PR TITLE
fix(v13): restore fleet and discovery compatibility

### DIFF
--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -2603,6 +2603,9 @@ func (b *OGame) galaxyInfos(galaxy, system int64, opts ...Option) (ogame.SystemI
 		"system": {utils.FI64(system)},
 	}
 	vals := url.Values{"page": {"ingame"}, "component": {"galaxy"}, "action": {"fetchGalaxyContent"}, "ajax": {"1"}, "asJson": {"1"}}
+	if ogVersion, err := version.NewVersion(sanitizeServerVersion(b.cache.serverData.Version)); err == nil && isVGreaterThanOrEqual(ogVersion, "13.0.0") {
+		vals = url.Values{"page": {"ingame"}, "component": {"galaxy"}, "action": {"fetchSolarSystemData"}, "asJson": {"1"}}
+	}
 	pageHTML, err := b.postPageContent(vals, payload, opts...)
 	if err != nil {
 		return res, err
@@ -2622,6 +2625,26 @@ func (b *OGame) galaxyInfos(galaxy, system int64, opts ...Option) (ogame.SystemI
 }
 
 func (b *OGame) getGalaxyPage(galaxy int64, system int64, opts ...Option) (*GalaxyPageContent, error) {
+	if ogVersion, err := version.NewVersion(sanitizeServerVersion(b.cache.serverData.Version)); err == nil && isVGreaterThanOrEqual(ogVersion, "13.0.0") {
+		by, err := b.postPageContent(url.Values{
+			"page":      {"ingame"},
+			"component": {"galaxy"},
+			"action":    {"fetchSolarSystemData"},
+			"asJson":    {"1"},
+		}, url.Values{
+			"galaxy": {strconv.Itoa(int(galaxy))},
+			"system": {strconv.Itoa(int(system))},
+		}, opts...)
+		if err != nil {
+			return nil, err
+		}
+		var res GalaxyPageContent
+		if err = json.Unmarshal(by, &res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+
 	// Get galaxy page content for the desired system.
 	by, err := b.postPageContent(url.Values{
 		"page":      {"ingame"},

--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -3303,6 +3303,7 @@ type CheckTargetResponse struct {
 	} `json:"targetPlanet"`
 	Errors          []OGameError `json:"errors"`
 	TargetOk        bool         `json:"targetOk"`
+	Message         string       `json:"message"`
 	Components      []any        `json:"components"`
 	EmptySystems    int64        `json:"emptySystems"`
 	InactiveSystems int64        `json:"inactiveSystems"`
@@ -3450,9 +3451,13 @@ func (b *OGame) sendFleet(celestialID ogame.CelestialID, ships ogame.ShipsInfos,
 		return zeroFleet, err
 	}
 
-	if !checkRes.TargetOk {
-		if len(checkRes.Errors) > 0 {
-			return zeroFleet, errors.New(checkRes.Errors[0].Message + " (" + strconv.Itoa(checkRes.Errors[0].Error) + ")")
+	targetAccepted := checkRes.TargetOk || (checkRes.Status == "success" && strings.EqualFold(strings.TrimSpace(checkRes.Message), "ok"))
+	if !targetAccepted {
+		if len(checkRes.Errors) > 0 && strings.TrimSpace(checkRes.Errors[0].Message) != "" {
+			return zeroFleet, fmt.Errorf("%s (%d)", checkRes.Errors[0].Message, checkRes.Errors[0].Error)
+		}
+		if message := strings.TrimSpace(checkRes.Message); message != "" && !strings.EqualFold(message, "ok") {
+			return zeroFleet, errors.New(message)
 		}
 		return zeroFleet, errors.New("target is not ok")
 	}


### PR DESCRIPTION
## Summary

- use `fetchSolarSystemData` for galaxy and discovery requests on OGame 13+
- preserve the legacy `fetchGalaxyContent` path for pre-v13 servers
- accept v13 `checkTarget` responses that return `status: "success"` and `message: "ok"` without `targetOk`
- propagate detailed fleet validation messages when available

## Cause

OGame 13 rejects `fetchGalaxyContent` with HTTP 405 and no longer returns `targetOk` in successful `checkTarget` responses. The existing v13 galaxy attempt also fell through to the legacy endpoint because the parsed response was not returned.

## Validation

- `go test ./pkg/wrapper`
- Xanthippe-pt `13.0.0-r8`: galaxy lookup HTTP 200
- Xanthippe-pt `13.0.0-r8`: 15 discovery positions returned
- Xanthippe-pt `13.0.0-r8`: discovery mission 18 sent successfully
- Xanthippe-pt `13.0.0-r8`: expedition sent successfully