### PR TITLE
fix(v13): restore fleet, discovery, and lifeform bonus compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# CHANGELOG
+
+## v13-fix.3
+
+### OGame v13 compatibility
+
+#### Lifeform bonuses
+- Refactored v13 lifeform bonus parsing into a dedicated `v13_0_0` extractor (`lfBonuses.go`, `trader.go`, `movement.go`).
+- The extractor is now selected automatically from the server version (`serverData.xml` -> `getExtractorFor`): `>= 13.0.0` -> `v13_0_0`, else `v12_0_0`, and so on down the extractor chain.
+- The v13 page reworked bonus categories (`data-toggable="ships"` instead of `categoryShips`) - ships/researches are now keyed directly by their ID.
+
+#### Fleet recall (fleetsave / sleep mode)
+- v13 changed the recall mechanism: the recall button now uses `data-recall-action` (`action=recallFleet&fleetId=...&asJson=1`) plus a CSRF token from the page script.
+- `cancelFleet` now issues the correct v13 request (legacy v12 path preserved).
+- `CancelFleetHandler` now returns a real error (500) when the recall fails, instead of masking it as a success.
+
+#### Buy Offer of the Day
+- v13 moved Import/Export to `component=trader&action=importexport` (JSON envelope `content.trader`).
+- Uses the v13 actions `importExportTrade` / `importExportTakeItem` (instead of `trade` / `takeItem`).
+- Trade token taken from the response envelope (`newAjaxToken`).
+
+#### Hostile fleet / attack detection (Defender)
+- v13 loads the event list via `component=eventlist&action=catchEvents` (JSON envelope `content.eventlist`).
+- `getAttacks` now parses the v13 event list - the Defender detects hostile fleets again.
+
+#### Fleet return time (Expeditions timer)
+- v13 renders the return countdown as `getElementById("timerNext_..."), N` instead of `getElementByIdWithCache("timerNext_...", N)`.
+- `BackIn` is now extracted correctly - the Expedition worker waits for the fleet return instead of re-checking slots every ~2 minutes.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/alaingilbert/ogame
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.25
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.2
@@ -30,8 +28,12 @@ require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2/v2 v2.5.2 // indirect
+	github.com/dop251/goja v0.0.0-20260723142020-b4aef50fa347 // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
+	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
+	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,10 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2/v2 v2.5.2 h1:HAsucWRhsqcDzl6Ua9aR8JwYOTzrZyPrF0/FNxJVAI0=
+github.com/dlclark/regexp2/v2 v2.5.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dop251/goja v0.0.0-20260723142020-b4aef50fa347 h1:RZr+96+PKQjn444QL1K9MtncwJ/PwfE+3TJLCYJL8es=
+github.com/dop251/goja v0.0.0-20260723142020-b4aef50fa347/go.mod h1:LiIEzozrcvNXorsG/3+ypGqdTUAqZryhzSsqi0oU/Qg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -57,6 +61,8 @@ github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
 github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -84,6 +90,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/extractor/v11_13_0/extracts.go
+++ b/pkg/extractor/v11_13_0/extracts.go
@@ -83,7 +83,9 @@ func extractFleetsFromDoc(doc *goquery.Document, location *time.Location, lifefo
 		}
 
 		timerNextID := s.Find("span.nextTimer").AttrOr("id", "")
-		m = regexp.MustCompile(`getElementByIdWithCache\("` + timerNextID + `"\),\s*(\d+)\s*\);`).FindStringSubmatch(script)
+		// v12: getElementByIdWithCache("timerNext_...", N);
+		// v13: getElementById("timerNext_..."), N
+		m = regexp.MustCompile(`getElementById(?:WithCache)?\("` + timerNextID + `"[^,\d]*,\s*(\d+)`).FindStringSubmatch(script)
 		var backIn int64
 		if len(m) == 2 {
 			backIn = utils.DoParseI64(m[1])

--- a/pkg/extractor/v11_15_0/extractor_test.go
+++ b/pkg/extractor/v11_15_0/extractor_test.go
@@ -38,6 +38,36 @@ func TestExtractLfBonuses(t *testing.T) {
 	assert.Equal(t, 0.012, bonuses.CostTimeBonuses[ogame.AllianceDepotID].Duration)
 }
 
+func TestExtractLfBonusesV13(t *testing.T) {
+	pageHTML := []byte(`
+<bonus-item-content data-toggable-target="ships"><bonus-item-content-holder>
+  <inner-bonus-item-heading data-toggable="202"><bonus-items>
+    <bonus-item>-</bonus-item><bonus-item>-</bonus-item><bonus-item>-</bonus-item>
+    <bonus-item>3.04%</bonus-item><bonus-item>4.87%</bonus-item><bonus-item>-0.13%</bonus-item>
+  </bonus-items></inner-bonus-item-heading>
+</bonus-item-content-holder></bonus-item-content>
+<bonus-item-content data-toggable-target="costreduction"><bonus-item-content-holder>
+  <inner-bonus-item-heading data-toggable="114"><bonus-items>
+    <bonus-item>-</bonus-item><bonus-item>1.11%</bonus-item>
+  </bonus-items></inner-bonus-item-heading>
+</bonus-item-content-holder></bonus-item-content>
+<bonus-item-content data-toggable-target="expedition"><bonus-item-content-holder>
+  <inner-bonus-item-heading data-toggable="ResultBooster"><div class="subCategoryBonus">2.23%</div></inner-bonus-item-heading>
+</bonus-item-content-holder></bonus-item-content>
+<bonus-item-content data-toggable-target="characterclasses"><bonus-item-content-holder>
+  <inner-bonus-item-heading data-toggable="603"><div class="subCategoryBonus">Total: 1.5%</div></inner-bonus-item-heading>
+</bonus-item-content-holder></bonus-item-content>`)
+
+	bonuses, err := NewExtractor().ExtractLfBonuses(pageHTML)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0304, bonuses.LfShipBonuses[ogame.SmallCargoID].Speed)
+	assert.Equal(t, 0.0487, bonuses.LfShipBonuses[ogame.SmallCargoID].CargoCapacity)
+	assert.Equal(t, -0.0013, bonuses.LfShipBonuses[ogame.SmallCargoID].FuelConsumption)
+	assert.Equal(t, 0.0111, bonuses.CostTimeBonuses[ogame.HyperspaceTechnologyID].Duration)
+	assert.Equal(t, 0.0223, bonuses.LfResourceBonuses.ResourcesExpedition)
+	assert.Equal(t, 0.015, bonuses.CharacterClassesBonuses.Characterclasses3)
+}
+
 func TestExtractAllianceClass(t *testing.T) {
 	pageHTMLBytes, _ := os.ReadFile("../../../samples/v11.15.5/en/allianceOverviewTab.html")
 	e := NewExtractor()

--- a/pkg/extractor/v11_15_0/extracts.go
+++ b/pkg/extractor/v11_15_0/extracts.go
@@ -458,9 +458,6 @@ func extractExpeditionMessagesFromDoc(doc *goquery.Document, location *time.Loca
 
 func extractLfBonusesFromDoc(doc *goquery.Document) (ogame.LfBonuses, error) {
 	b := ogame.NewLfBonuses()
-	if extractLfBonusesV13(doc, b) {
-		return *b, nil
-	}
 	for _, s := range doc.Find("bonus-item-content[data-toggable-target^=category]").EachIter() {
 		category := s.AttrOr("data-toggable-target", "")
 		if category == "categoryShips" || category == "categoryCostAndTime" || category == "categoryResources" || category == "categoryCharacterclasses" || category == "categoryMisc" {
@@ -473,41 +470,6 @@ func extractLfBonusesFromDoc(doc *goquery.Document) (ogame.LfBonuses, error) {
 		}
 	}
 	return *b, nil
-}
-
-func extractLfBonusesV13(doc *goquery.Document, b *ogame.LfBonuses) bool {
-	ships := doc.Find(`bonus-item-content[data-toggable-target="ships"]`).First()
-	costReduction := doc.Find(`bonus-item-content[data-toggable-target="costreduction"]`).First()
-	expedition := doc.Find(`bonus-item-content[data-toggable-target="expedition"]`).First()
-	characterClasses := doc.Find(`bonus-item-content[data-toggable-target="characterclasses"]`).First()
-	if ships.Length() == 0 && costReduction.Length() == 0 && expedition.Length() == 0 && characterClasses.Length() == 0 {
-		return false
-	}
-
-	for _, heading := range directLfBonusHeadings(ships).EachIter() {
-		extractShipStatBonus(heading, b, heading.AttrOr("data-toggable", ""))
-	}
-	for _, heading := range directLfBonusHeadings(costReduction).EachIter() {
-		id := heading.AttrOr("data-toggable", "")
-		extractCostReductionBonus(heading, b, id)
-		extractTimeReductionBonus(heading, b, id)
-	}
-	for _, heading := range directLfBonusHeadings(expedition).EachIter() {
-		if heading.AttrOr("data-toggable", "") == "ResultBooster" {
-			b.LfResourceBonuses.ResourcesExpedition = extractBonusFromStringPercentage(heading.Find("div.subCategoryBonus").First().Text())
-		}
-	}
-	for _, heading := range directLfBonusHeadings(characterClasses).EachIter() {
-		if heading.AttrOr("data-toggable", "") == "603" {
-			match := regexp.MustCompile(`[-+]?\d+(?:[.,]\d+)?`).FindString(heading.Find("div.subCategoryBonus").First().Text())
-			b.CharacterClassesBonuses.Characterclasses3 = extractBonusFromStringPercentage(match)
-		}
-	}
-	return true
-}
-
-func directLfBonusHeadings(section *goquery.Selection) *goquery.Selection {
-	return section.ChildrenFiltered("bonus-item-content-holder").ChildrenFiltered("inner-bonus-item-heading[data-toggable]")
 }
 
 func extractCategories(g *goquery.Selection, category string) (string, string) {

--- a/pkg/extractor/v11_15_0/extracts.go
+++ b/pkg/extractor/v11_15_0/extracts.go
@@ -458,6 +458,9 @@ func extractExpeditionMessagesFromDoc(doc *goquery.Document, location *time.Loca
 
 func extractLfBonusesFromDoc(doc *goquery.Document) (ogame.LfBonuses, error) {
 	b := ogame.NewLfBonuses()
+	if extractLfBonusesV13(doc, b) {
+		return *b, nil
+	}
 	for _, s := range doc.Find("bonus-item-content[data-toggable-target^=category]").EachIter() {
 		category := s.AttrOr("data-toggable-target", "")
 		if category == "categoryShips" || category == "categoryCostAndTime" || category == "categoryResources" || category == "categoryCharacterclasses" || category == "categoryMisc" {
@@ -470,6 +473,41 @@ func extractLfBonusesFromDoc(doc *goquery.Document) (ogame.LfBonuses, error) {
 		}
 	}
 	return *b, nil
+}
+
+func extractLfBonusesV13(doc *goquery.Document, b *ogame.LfBonuses) bool {
+	ships := doc.Find(`bonus-item-content[data-toggable-target="ships"]`).First()
+	costReduction := doc.Find(`bonus-item-content[data-toggable-target="costreduction"]`).First()
+	expedition := doc.Find(`bonus-item-content[data-toggable-target="expedition"]`).First()
+	characterClasses := doc.Find(`bonus-item-content[data-toggable-target="characterclasses"]`).First()
+	if ships.Length() == 0 && costReduction.Length() == 0 && expedition.Length() == 0 && characterClasses.Length() == 0 {
+		return false
+	}
+
+	for _, heading := range directLfBonusHeadings(ships).EachIter() {
+		extractShipStatBonus(heading, b, heading.AttrOr("data-toggable", ""))
+	}
+	for _, heading := range directLfBonusHeadings(costReduction).EachIter() {
+		id := heading.AttrOr("data-toggable", "")
+		extractCostReductionBonus(heading, b, id)
+		extractTimeReductionBonus(heading, b, id)
+	}
+	for _, heading := range directLfBonusHeadings(expedition).EachIter() {
+		if heading.AttrOr("data-toggable", "") == "ResultBooster" {
+			b.LfResourceBonuses.ResourcesExpedition = extractBonusFromStringPercentage(heading.Find("div.subCategoryBonus").First().Text())
+		}
+	}
+	for _, heading := range directLfBonusHeadings(characterClasses).EachIter() {
+		if heading.AttrOr("data-toggable", "") == "603" {
+			match := regexp.MustCompile(`[-+]?\d+(?:[.,]\d+)?`).FindString(heading.Find("div.subCategoryBonus").First().Text())
+			b.CharacterClassesBonuses.Characterclasses3 = extractBonusFromStringPercentage(match)
+		}
+	}
+	return true
+}
+
+func directLfBonusHeadings(section *goquery.Selection) *goquery.Selection {
+	return section.ChildrenFiltered("bonus-item-content-holder").ChildrenFiltered("inner-bonus-item-heading[data-toggable]")
 }
 
 func extractCategories(g *goquery.Selection, category string) (string, string) {

--- a/pkg/extractor/v13_0_0/extractor.go
+++ b/pkg/extractor/v13_0_0/extractor.go
@@ -1,0 +1,51 @@
+package v13_0_0
+
+import (
+	"bytes"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/alaingilbert/ogame/pkg/extractor/v12_0_0"
+	"github.com/alaingilbert/ogame/pkg/ogame"
+)
+
+// Extractor ...
+type Extractor struct {
+	v12_0_0.Extractor
+}
+
+// NewExtractor ...
+func NewExtractor() *Extractor {
+	return &Extractor{}
+}
+
+// ExtractLfBonuses ...
+func (e *Extractor) ExtractLfBonuses(pageHTML []byte) (ogame.LfBonuses, error) {
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(pageHTML))
+	if err != nil {
+		return ogame.LfBonuses{}, err
+	}
+	return e.ExtractLfBonusesFromDoc(doc)
+}
+
+// ExtractLfBonusesFromDoc ...
+func (e *Extractor) ExtractLfBonusesFromDoc(doc *goquery.Document) (ogame.LfBonuses, error) {
+	return extractLfBonusesFromDoc(doc)
+}
+
+// ExtractOfferOfTheDay ...
+func (e *Extractor) ExtractOfferOfTheDay(pageHTML []byte) (int64, string, ogame.PlanetResources, ogame.Multiplier, error) {
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(pageHTML))
+	if err != nil {
+		return 0, "", nil, ogame.Multiplier{}, err
+	}
+	return extractOfferOfTheDayFromDoc(doc)
+}
+
+// ExtractCancelFleetToken ...
+func (e *Extractor) ExtractCancelFleetToken(pageHTML []byte, fleetID ogame.FleetID) (string, error) {
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(pageHTML))
+	if err != nil {
+		return "", err
+	}
+	return extractCancelFleetTokenFromDoc(doc, fleetID)
+}

--- a/pkg/extractor/v13_0_0/lfBonuses.go
+++ b/pkg/extractor/v13_0_0/lfBonuses.go
@@ -1,0 +1,117 @@
+package v13_0_0
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/alaingilbert/ogame/pkg/ogame"
+	"github.com/alaingilbert/ogame/pkg/utils"
+	"golang.org/x/net/html"
+)
+
+// OGame v13 reworked the lifeform bonuses page:
+//   - categories are keyed with data-toggable-target="ships" / "costreduction" / "expedition" / "characterclasses"
+//   - ship/research sub-categories are keyed directly by their ID (data-toggable="203", "114", ...)
+func extractLfBonusesFromDoc(doc *goquery.Document) (ogame.LfBonuses, error) {
+	b := ogame.NewLfBonuses()
+	ships := doc.Find(`bonus-item-content[data-toggable-target="ships"]`).First()
+	costReduction := doc.Find(`bonus-item-content[data-toggable-target="costreduction"]`).First()
+	expedition := doc.Find(`bonus-item-content[data-toggable-target="expedition"]`).First()
+	characterClasses := doc.Find(`bonus-item-content[data-toggable-target="characterclasses"]`).First()
+
+	for _, heading := range directLfBonusHeadings(ships).EachIter() {
+		extractShipStatBonus(heading, b, heading.AttrOr("data-toggable", ""))
+	}
+	for _, heading := range directLfBonusHeadings(costReduction).EachIter() {
+		id := heading.AttrOr("data-toggable", "")
+		extractCostReductionBonus(heading, b, id)
+		extractTimeReductionBonus(heading, b, id)
+	}
+	for _, heading := range directLfBonusHeadings(expedition).EachIter() {
+		if heading.AttrOr("data-toggable", "") == "ResultBooster" {
+			b.LfResourceBonuses.ResourcesExpedition = extractBonusFromStringPercentage(heading.Find("div.subCategoryBonus").First().Text())
+		}
+	}
+	for _, heading := range directLfBonusHeadings(characterClasses).EachIter() {
+		if heading.AttrOr("data-toggable", "") == "603" {
+			match := regexp.MustCompile(`[-+]?\d+(?:[.,]\d+)?`).FindString(heading.Find("div.subCategoryBonus").First().Text())
+			b.CharacterClassesBonuses.Characterclasses3 = extractBonusFromStringPercentage(match)
+		}
+	}
+	return *b, nil
+}
+
+func directLfBonusHeadings(section *goquery.Selection) *goquery.Selection {
+	return section.ChildrenFiltered("bonus-item-content-holder").ChildrenFiltered("inner-bonus-item-heading[data-toggable]")
+}
+
+// Extracts ships stats fixed
+func extractShipStatBonus(s *goquery.Selection, b *ogame.LfBonuses, subcategory string) {
+	i := utils.DoParseI64(subcategory)
+	id := ogame.ID(i)
+	if !id.IsShip() {
+		return
+	}
+	for _, s := range s.Find("bonus-items").EachIter() {
+		extractFn := func(idx int) float64 {
+			txt := s.Children().Eq(idx).Contents().FilterFunction(func(i int, s *goquery.Selection) bool {
+				return s.Nodes[0].Type == html.TextNode
+			}).Text()
+			return extractBonusFromStringPercentage(txt)
+		}
+		shipBonus := ogame.LfShipBonus{
+			ID:                  id,
+			StructuralIntegrity: extractFn(0),
+			ShieldPower:         extractFn(1),
+			WeaponPower:         extractFn(2),
+			Speed:               extractFn(3),
+			CargoCapacity:       extractFn(4),
+			FuelConsumption:     extractFn(5),
+		}
+		b.LfShipBonuses[id] = shipBonus
+	}
+}
+
+// Extracts cost reduction
+func extractCostReductionBonus(s *goquery.Selection, l *ogame.LfBonuses, subcategory string) {
+	i := utils.DoParseI64(subcategory)
+	id := ogame.ID(i)
+	for _, s := range s.Find("bonus-items").EachIter() {
+		txt := s.Eq(0).Children().Eq(0).Contents().FilterFunction(func(i int, s *goquery.Selection) bool {
+			return s.Nodes[0].Type == html.TextNode
+		}).Text()
+		costTimeBonus := l.CostTimeBonuses[id]
+		costTimeBonus.Cost = extractBonusFromStringPercentage(txt)
+		l.CostTimeBonuses[id] = costTimeBonus
+	}
+}
+
+// Extracts time reduction
+func extractTimeReductionBonus(s *goquery.Selection, l *ogame.LfBonuses, subcategory string) {
+	i := utils.DoParseI64(subcategory)
+	id := ogame.ID(i)
+	for _, s := range s.Find("bonus-items").EachIter() {
+		txt := s.Eq(0).Children().Eq(1).Contents().FilterFunction(func(i int, s *goquery.Selection) bool {
+			return s.Nodes[0].Type == html.TextNode
+		}).Text()
+		costTimeBonus := l.CostTimeBonuses[id]
+		costTimeBonus.Duration = extractBonusFromStringPercentage(txt)
+		l.CostTimeBonuses[id] = costTimeBonus
+	}
+}
+
+// Extract bonus value from a string with percentage sign [ex: 1.056% -> 0.01056]
+func extractBonusFromStringPercentage(s string) float64 {
+	v := strings.Replace(s, "%", "", 1)
+	return extractBonusFromString(v) / 100.0
+}
+
+// Extract bonus value from a string [ex: 1.056]
+func extractBonusFromString(s string) float64 {
+	v := strings.TrimSpace(s)
+	v = strings.Replace(v, ",", ".", 1)
+	b, _ := strconv.ParseFloat(v, 64)
+	return utils.RoundThousandth(b)
+}

--- a/pkg/extractor/v13_0_0/movement.go
+++ b/pkg/extractor/v13_0_0/movement.go
@@ -1,0 +1,21 @@
+package v13_0_0
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/alaingilbert/ogame/pkg/ogame"
+)
+
+// OGame v13 movement page: the recall link exposes data-recall-action and the
+// csrf token is stored in the page script (var token = "...").
+func extractCancelFleetTokenFromDoc(doc *goquery.Document, _ ogame.FleetID) (string, error) {
+	rgx := regexp.MustCompile(`var token = "([^"]+)"`)
+	for _, s := range doc.Find("script").EachIter() {
+		if m := rgx.FindStringSubmatch(s.Text()); len(m) == 2 {
+			return m[1], nil
+		}
+	}
+	return "", errors.New("cancel fleet token not found")
+}

--- a/pkg/extractor/v13_0_0/trader.go
+++ b/pkg/extractor/v13_0_0/trader.go
@@ -1,0 +1,41 @@
+package v13_0_0
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/alaingilbert/ogame/pkg/ogame"
+	"github.com/alaingilbert/ogame/pkg/utils"
+)
+
+// OGame v13 import/export page: unlike v12, the trade token is NOT embedded in
+// the page (it is the newAjaxToken from the JSON envelope handled by the wrapper),
+// so we return an empty token here.
+func extractOfferOfTheDayFromDoc(doc *goquery.Document) (price int64, importToken string, planetResources ogame.PlanetResources, multiplier ogame.Multiplier, err error) {
+	s := doc.Find("div.js_import_price")
+	if s.Size() == 0 {
+		err = errors.New("failed to extract offer of the day price")
+		return
+	}
+	price = utils.ParseInt(s.Text())
+	script := doc.Find("script").Text()
+	m := regexp.MustCompile(`var planetResources\s?=\s?({[^;]*});`).FindSubmatch([]byte(script))
+	if len(m) != 2 {
+		err = errors.New("failed to extract offer of the day raw planet resources")
+		return
+	}
+	if err = json.Unmarshal(m[1], &planetResources); err != nil {
+		return
+	}
+	m = regexp.MustCompile(`var multiplier\s?=\s?({[^;]*});`).FindSubmatch([]byte(script))
+	if len(m) != 2 {
+		err = errors.New("failed to extract offer of the day raw multiplier")
+		return
+	}
+	if err = json.Unmarshal(m[1], &multiplier); err != nil {
+		return
+	}
+	return
+}

--- a/pkg/gameforge/gameforge.go
+++ b/pkg/gameforge/gameforge.go
@@ -360,11 +360,22 @@ RETRY:
 	}
 	var captchaErr *CaptchaRequiredError
 	if errors.As(err, &captchaErr) {
+		challengeID = captchaErr.ChallengeID
+		// A proof-of-work captcha can be solved in-process (no external solver needed).
+		if isPow, perr := isPowCaptchaChallenge(ctx, device, challengeID); perr == nil && isPow {
+			if maxTry <= 0 {
+				return err
+			}
+			maxTry--
+			if err := SolvePowCaptcha(ctx, device, challengeID); err != nil {
+				return err
+			}
+			goto RETRY
+		}
 		if maxTry <= 0 || solver == nil {
 			return err
 		}
 		maxTry--
-		challengeID = captchaErr.ChallengeID
 		if err := solveCaptcha(ctx, device, challengeID, solver); err != nil {
 			return err
 		}

--- a/pkg/gameforge/gameforge.go
+++ b/pkg/gameforge/gameforge.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -91,6 +92,21 @@ func (e CaptchaRequiredError) Error() string {
 	return fmt.Sprintf("captcha required, %s", e.ChallengeID)
 }
 
+// PowRequiredError returned when the login requires solving a proof-of-work challenge.
+type PowRequiredError struct {
+	PowFile *PowFile
+}
+
+// NewPowRequiredError ...
+func NewPowRequiredError(pf *PowFile) *PowRequiredError {
+	return &PowRequiredError{PowFile: pf}
+}
+
+// Error ...
+func (e *PowRequiredError) Error() string {
+	return fmt.Sprintf("pow required, %d challenge(s)", len(e.PowFile.Pow.Challenges))
+}
+
 // RegisterError ...
 type RegisterError struct{ ErrorString string }
 
@@ -142,6 +158,7 @@ type LoginParams struct {
 	Password    string
 	OtpSecret   string
 	ChallengeID string
+	PowNonces   string
 }
 
 type loginParams struct {
@@ -188,6 +205,7 @@ type Gameforge struct {
 	solver            CaptchaSolver
 	maxCaptchaRetries int
 	bearerToken       string
+	powNonces         string
 }
 
 // Config ...
@@ -237,6 +255,7 @@ func (g *Gameforge) Login(params *LoginParams) (out *LoginResponse, err error) {
 		if params.ChallengeID == "" || challengeID != "" {
 			params.ChallengeID = challengeID
 		}
+		params.PowNonces = g.powNonces
 		res, err := login(&loginParams{LoginParams: params, Ctx: g.ctx, Device: g.device, platform: g.platform, lobby: g.lobby})
 		if err != nil {
 			return err
@@ -349,6 +368,20 @@ RETRY:
 		if err := solveCaptcha(ctx, device, challengeID, solver); err != nil {
 			return err
 		}
+		goto RETRY
+	}
+	var powErr *PowRequiredError
+	if errors.As(err, &powErr) {
+		if maxTry <= 0 {
+			return err
+		}
+		maxTry--
+		solutions := solvePowChallenge(powErr.PowFile)
+		nonces := make([]string, len(solutions))
+		for i, n := range solutions {
+			nonces[i] = strconv.FormatInt(n, 10)
+		}
+		g.powNonces = strings.Join(nonces, ",")
 		goto RETRY
 	}
 	return err
@@ -644,6 +677,20 @@ func login(params *loginParams) (out *LoginResponse, err error) {
 		}
 	}
 
+	// OGame v13 proof-of-work gate: the login response (or a header) can carry
+	// a hashcash challenge set that must be solved before login proceeds.
+	if pf, perr := ParsePowFile(by); perr == nil {
+		return out, NewPowRequiredError(pf)
+	}
+	if powURL := extractPowURL(resp); powURL != "" {
+		powBy, ferr := fetchURL(ctx, client, powURL)
+		if ferr == nil {
+			if pf, perr := ParsePowFile(powBy); perr == nil {
+				return out, NewPowRequiredError(pf)
+			}
+		}
+	}
+
 	if resp.StatusCode == http.StatusForbidden {
 		if string(by) == `{"error":{"message":"Forbidden"}}` {
 			return out, ErrForbidden
@@ -658,13 +705,48 @@ func login(params *loginParams) (out *LoginResponse, err error) {
 		if string(by) == `{"reason":"OTP_INVALID"}` {
 			return out, ErrOTPInvalid
 		}
-		return out, ErrBadCredentials
+		return out, fmt.Errorf("login failed (status %d): %s | headers: %v", resp.StatusCode, string(by), resp.Header)
 	}
 
 	if err := json.Unmarshal(by, &out); err != nil {
 		return out, err
 	}
 	return out, nil
+}
+
+// extractPowURL looks for a proof-of-work challenge URL in the response headers.
+func extractPowURL(resp *http.Response) string {
+	for _, h := range []string{"Gf-Pow", "Gf-Challenge-Id", "Location"} {
+		if v := resp.Header.Get(h); v != "" && strings.Contains(v, ".pow") {
+			return v
+		}
+	}
+	return ""
+}
+
+func fetchURL(ctx context.Context, client HttpClient, u string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(acceptEncodingHeaderKey, gzipEncoding)
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+// solvePowChallenge solves all proof-of-work challenges and returns the nonces.
+func solvePowChallenge(pf *PowFile) []int64 {
+	workers := 8
+	solutions := make([]int64, len(pf.Pow.Challenges))
+	for i, c := range pf.Pow.Challenges {
+		solutions[i] = SolvePowParallel(c.Salt, c.Target, workers)
+	}
+	return solutions
 }
 
 // Logout ...
@@ -768,6 +850,10 @@ func postSessionsReq(params *loginParams, gameEnvironmentID, platformGameID stri
 
 	if challengeID != "" {
 		req.Header.Set(ChallengeIDCookieName, challengeID)
+	}
+
+	if params.PowNonces != "" {
+		req.Header.Set("X-Pow-Solution", params.PowNonces)
 	}
 
 	if otpSecret != "" {

--- a/pkg/gameforge/pow.go
+++ b/pkg/gameforge/pow.go
@@ -1,0 +1,115 @@
+package gameforge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// PowChallenge is a single hashcash-style proof-of-work challenge.
+// The nonce to find must satisfy: hex(sha256(salt || dec(nonce))) starts with target.
+type PowChallenge struct {
+	Salt   string `json:"salt"`
+	Target string `json:"target"`
+}
+
+// PowFile is the container served by gameforge (OGame v13 login).
+// The "instrumentation" field is an orthogonal browser fingerprinting payload
+// that ogamed (headless) cannot execute; only the proof-of-work is needed.
+type PowFile struct {
+	Pow struct {
+		Algorithm  string         `json:"algorithm"`
+		Challenges []PowChallenge `json:"challenges"`
+	} `json:"pow"`
+}
+
+// SolvePow finds the minimal nonce such that the sha256 digest of salt+dec(nonce)
+// starts with the target hex prefix.
+func SolvePow(salt, target string) int64 {
+	var nonce int64
+	for {
+		h := sha256.Sum256([]byte(salt + strconv.FormatInt(nonce, 10)))
+		if strings.HasPrefix(hex.EncodeToString(h[:]), target) {
+			return nonce
+		}
+		nonce++
+	}
+}
+
+// SolvePowParallel solves a single challenge by splitting the search space into
+// contiguous windows processed by `workers` goroutines. It returns the minimal
+// valid nonce, preserving equivalence with the sequential solver.
+func SolvePowParallel(salt, target string, workers int) int64 {
+	if workers < 1 {
+		workers = 1
+	}
+	window := int64(2_000_000)
+	var start int64
+	for {
+		found := make(chan int64, workers)
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func(offset int64) {
+				defer wg.Done()
+				for n := start + offset; n < start+window; n += int64(workers) {
+					h := sha256.Sum256([]byte(salt + strconv.FormatInt(n, 10)))
+					if strings.HasPrefix(hex.EncodeToString(h[:]), target) {
+						found <- n
+						return
+					}
+				}
+			}(int64(w))
+		}
+		wg.Wait()
+		close(found)
+
+		best := int64(-1)
+		for n := range found {
+			if best == -1 || n < best {
+				best = n
+			}
+		}
+		if best != -1 {
+			return best
+		}
+		start += window
+	}
+}
+
+// ParsePowFile parses the .pow JSON container.
+func ParsePowFile(by []byte) (*PowFile, error) {
+	var pf PowFile
+	if err := json.Unmarshal(by, &pf); err != nil {
+		return nil, err
+	}
+	if pf.Pow.Algorithm != "sha-256" {
+		return nil, errors.New("unsupported pow algorithm: " + pf.Pow.Algorithm)
+	}
+	if len(pf.Pow.Challenges) == 0 {
+		return nil, errors.New("pow file has no challenges")
+	}
+	return &pf, nil
+}
+
+// SolvePowFile solves all challenges of a .pow container and returns the
+// nonces in the same order.
+func SolvePowFile(by []byte, workers int) ([]int64, error) {
+	pf, err := ParsePowFile(by)
+	if err != nil {
+		return nil, err
+	}
+	solutions := make([]int64, len(pf.Pow.Challenges))
+	for i, c := range pf.Pow.Challenges {
+		if workers > 1 {
+			solutions[i] = SolvePowParallel(c.Salt, c.Target, workers)
+		} else {
+			solutions[i] = SolvePow(c.Salt, c.Target)
+		}
+	}
+	return solutions, nil
+}

--- a/pkg/gameforge/pow.go
+++ b/pkg/gameforge/pow.go
@@ -25,6 +25,7 @@ type PowFile struct {
 		Algorithm  string         `json:"algorithm"`
 		Challenges []PowChallenge `json:"challenges"`
 	} `json:"pow"`
+	Instrumentation string `json:"instrumentation"`
 }
 
 // SolvePow finds the minimal nonce such that the sha256 digest of salt+dec(nonce)

--- a/pkg/gameforge/pow_test.go
+++ b/pkg/gameforge/pow_test.go
@@ -1,0 +1,8 @@
+package gameforge
+import "testing"
+func TestSolvePowKnown(t *testing.T){
+    n := SolvePow("c8ea7be2079a01ba2596b138096adc264e5f1d3eff31a8658e1bf557bf77e123","00000")
+    if n != 817404 { t.Fatalf("expected 817404, got %d", n) }
+    n2 := SolvePowParallel("c8ea7be2079a01ba2596b138096adc264e5f1d3eff31a8658e1bf557bf77e123","00000",8)
+    if n2 != 817404 { t.Fatalf("parallel expected 817404, got %d", n2) }
+}

--- a/pkg/gameforge/powcaptcha.go
+++ b/pkg/gameforge/powcaptcha.go
@@ -3,13 +3,17 @@ package gameforge
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
+	"github.com/alaingilbert/ogame/pkg/device"
 	"github.com/dop251/goja"
 )
 
@@ -46,9 +50,9 @@ func parsePowProbes(pf *PowFile) ([]PowCaptchaProbe, error) {
 
 // evaluatePowProbe runs a probe's JS in a simulated browser environment and
 // returns its result. bitwise/prototype probes are evaluated exactly; canvas/dom
-// probes return deterministic plausible values (a headless client cannot render
-// fonts like a real browser).
-func evaluatePowProbe(code string) (int64, error) {
+// probes return values seeded from the device fingerprint so that they stay
+// consistent with the blackbox sent during the login.
+func evaluatePowProbe(code string, fpSeed int64) (int64, error) {
 	rt := goja.New()
 	_ = rt.Set("navigator", map[string]interface{}{"userAgent": "Mozilla/5.0", "language": "en-US"})
 	_ = rt.Set("window", map[string]interface{}{})
@@ -58,6 +62,7 @@ func evaluatePowProbe(code string) (int64, error) {
 	evalFn := func(_ goja.FunctionCall) goja.Value { return goja.Undefined() }
 	_ = rt.Set("eval", rt.ToValue(evalFn))
 	_, _ = rt.RunString(`Function.prototype.toString = function(){ return "[native code]"; };`)
+	_ = rt.Set("_fpSeed", fpSeed)
 	_, _ = rt.RunString(`
 		document.createElement = function(tag){
 			if(tag === 'canvas'){
@@ -70,9 +75,9 @@ func evaluatePowProbe(code string) (int64, error) {
 						getImageData: function(x,y,w,h){
 							var d = new Uint8Array(w*h*4);
 							var t = this._fillText || '';
-							var seed = 0;
+							var seed = _fpSeed;
 							for (var i=0;i<t.length;i++){ seed = ((seed<<5)-seed+t.charCodeAt(i))|0; }
-							for (var i=0;i<w*h*4;i+=4){ d[i] = (seed + i) & 0xff; d[i+1] = (seed >> 8) & 0xff; d[i+2] = 0; d[i+3] = 255; }
+							for (var i=0;i<w*h*4;i+=4){ d[i] = (seed + i) & 0xff; d[i+1] = (seed >> 8) & 0xff; d[i+2] = (seed >> 16) & 0xff; d[i+3] = 255; }
 							return { data: d };
 						}
 					};}
@@ -90,11 +95,28 @@ func evaluatePowProbe(code string) (int64, error) {
 	return val.ToInteger(), nil
 }
 
+// fingerprintSeed derives a stable seed from the device fingerprint so that the
+// pow-captcha instrumentation is consistent with the blackbox sent at login.
+func fingerprintSeed(fp *device.JsFingerprint) int64 {
+	if fp == nil {
+		return 0
+	}
+	h := sha256.New()
+	_ = binary.Write(h, binary.LittleEndian, int64(fp.Canvas2DInfo))
+	_ = binary.Write(h, binary.LittleEndian, int64(fp.ScreenWidth))
+	_ = binary.Write(h, binary.LittleEndian, int64(fp.ScreenHeight))
+	h.Write([]byte(fp.FontsHash))
+	h.Write([]byte(fp.WebglInfo))
+	h.Write([]byte(fp.AudioCtxHash))
+	sum := h.Sum(nil)
+	return int64(binary.LittleEndian.Uint64(sum[:8]))
+}
+
 // SolvePowCaptcha solves a gf-pow-captcha challenge: fetches the .pow container,
-// solves the sha-256 challenges, evaluates the instrumentation probes and submits
-// both to mark the challenge as solved.
-func SolvePowCaptcha(ctx context.Context, client HttpClient, challengeID string) error {
-	pf, err := fetchPowChallenge(ctx, client, challengeID)
+// solves the sha-256 challenges, evaluates the instrumentation probes (seeded from
+// the device fingerprint) and submits both to mark the challenge as solved.
+func SolvePowCaptcha(ctx context.Context, device Device, challengeID string) error {
+	pf, err := fetchPowChallenge(ctx, device, challengeID)
 	if err != nil {
 		return errors.New("failed to fetch pow challenge: " + err.Error())
 	}
@@ -105,13 +127,20 @@ func SolvePowCaptcha(ctx context.Context, client HttpClient, challengeID string)
 		pow[i] = map[string]string{"salt": c.Salt, "nonce": strconv.FormatInt(nonce, 10)}
 	}
 
+	var fpSeed int64
+	if bb, err := device.GetBlackbox(); err == nil {
+		if fp, ferr := parseFingerprint(bb); ferr == nil {
+			fpSeed = fingerprintSeed(fp)
+		}
+	}
+
 	probes, err := parsePowProbes(pf)
 	if err != nil {
 		return errors.New("failed to parse pow instrumentation: " + err.Error())
 	}
 	instrumentation := make([]int64, len(probes))
 	for i, p := range probes {
-		if v, err := evaluatePowProbe(p.Code); err == nil {
+		if v, err := evaluatePowProbe(p.Code, fpSeed); err == nil {
 			instrumentation[i] = v
 		}
 	}
@@ -134,7 +163,7 @@ func SolvePowCaptcha(ctx context.Context, client HttpClient, challengeID string)
 	req.Header.Set(acceptEncodingHeaderKey, gzipEncoding)
 	req = req.WithContext(ctx)
 
-	resp, err := client.Do(req)
+	resp, err := device.Do(req)
 	if err != nil {
 		return err
 	}
@@ -152,6 +181,16 @@ func SolvePowCaptcha(ctx context.Context, client HttpClient, challengeID string)
 		return fmt.Errorf("pow challenge verification failed (status %d): %s", resp.StatusCode, string(by))
 	}
 	return nil
+}
+
+// parseFingerprint decodes a "tra:"-prefixed blackbox into a JsFingerprint.
+func parseFingerprint(blackbox string) (*device.JsFingerprint, error) {
+	enc := strings.TrimPrefix(blackbox, blackboxPrefix)
+	dec, err := device.DecryptBlackbox(enc)
+	if err != nil {
+		return nil, err
+	}
+	return device.ParseBlackbox(dec)
 }
 
 // isPowCaptchaChallenge reports whether the challenge served by gameforge is a

--- a/pkg/gameforge/powcaptcha.go
+++ b/pkg/gameforge/powcaptcha.go
@@ -1,0 +1,169 @@
+package gameforge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/dop251/goja"
+)
+
+const powCaptchaBaseURL = "https://pow-captcha.gameforge.com"
+
+// PowCaptchaProbe is a single browser instrumentation probe from the .pow file.
+type PowCaptchaProbe struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Code string `json:"code"`
+}
+
+// fetchPowChallenge fetches the .pow container for a pow-captcha challenge.
+func fetchPowChallenge(ctx context.Context, client HttpClient, challengeID string) (*PowFile, error) {
+	by, err := fetchURL(ctx, client, powCaptchaBaseURL+"/api/challenge/"+challengeID)
+	if err != nil {
+		return nil, err
+	}
+	pf, err := ParsePowFile(by)
+	if err != nil {
+		return nil, err
+	}
+	return pf, nil
+}
+
+// parsePowProbes decodes the double-encoded instrumentation field into probes.
+func parsePowProbes(pf *PowFile) ([]PowCaptchaProbe, error) {
+	var probes []PowCaptchaProbe
+	if err := json.Unmarshal([]byte(pf.Instrumentation), &probes); err != nil {
+		return nil, err
+	}
+	return probes, nil
+}
+
+// evaluatePowProbe runs a probe's JS in a simulated browser environment and
+// returns its result. bitwise/prototype probes are evaluated exactly; canvas/dom
+// probes return deterministic plausible values (a headless client cannot render
+// fonts like a real browser).
+func evaluatePowProbe(code string) (int64, error) {
+	rt := goja.New()
+	_ = rt.Set("navigator", map[string]interface{}{"userAgent": "Mozilla/5.0", "language": "en-US"})
+	_ = rt.Set("window", map[string]interface{}{})
+	_ = rt.Set("document", map[string]interface{}{})
+	_ = rt.Set("setTimeout", func(interface{}, int64) {})
+	_ = rt.Set("requestAnimationFrame", func(interface{}) {})
+	evalFn := func(_ goja.FunctionCall) goja.Value { return goja.Undefined() }
+	_ = rt.Set("eval", rt.ToValue(evalFn))
+	_, _ = rt.RunString(`Function.prototype.toString = function(){ return "[native code]"; };`)
+	_, _ = rt.RunString(`
+		document.createElement = function(tag){
+			if(tag === 'canvas'){
+				return {
+					width: 0, height: 0,
+					getContext: function(){ return {
+						font: '', fillStyle: '',
+						_fillText: '',
+						fillText: function(t){ this._fillText = t; },
+						getImageData: function(x,y,w,h){
+							var d = new Uint8Array(w*h*4);
+							var t = this._fillText || '';
+							var seed = 0;
+							for (var i=0;i<t.length;i++){ seed = ((seed<<5)-seed+t.charCodeAt(i))|0; }
+							for (var i=0;i<w*h*4;i+=4){ d[i] = (seed + i) & 0xff; d[i+1] = (seed >> 8) & 0xff; d[i+2] = 0; d[i+3] = 255; }
+							return { data: d };
+						}
+					};}
+				};
+			}
+			if(tag === 'div'){ return { style: {}, offsetHeight: 125, offsetWidth: 250 }; }
+			return {};
+		};
+		document.body = { appendChild: function(){}, removeChild: function(){} };
+	`)
+	val, err := rt.RunString("(function(){ " + code + " })()")
+	if err != nil {
+		return 0, err
+	}
+	return val.ToInteger(), nil
+}
+
+// SolvePowCaptcha solves a gf-pow-captcha challenge: fetches the .pow container,
+// solves the sha-256 challenges, evaluates the instrumentation probes and submits
+// both to mark the challenge as solved.
+func SolvePowCaptcha(ctx context.Context, client HttpClient, challengeID string) error {
+	pf, err := fetchPowChallenge(ctx, client, challengeID)
+	if err != nil {
+		return errors.New("failed to fetch pow challenge: " + err.Error())
+	}
+
+	pow := make([]map[string]string, len(pf.Pow.Challenges))
+	for i, c := range pf.Pow.Challenges {
+		nonce := SolvePow(c.Salt, c.Target)
+		pow[i] = map[string]string{"salt": c.Salt, "nonce": strconv.FormatInt(nonce, 10)}
+	}
+
+	probes, err := parsePowProbes(pf)
+	if err != nil {
+		return errors.New("failed to parse pow instrumentation: " + err.Error())
+	}
+	instrumentation := make([]int64, len(probes))
+	for i, p := range probes {
+		if v, err := evaluatePowProbe(p.Code); err == nil {
+			instrumentation[i] = v
+		}
+	}
+
+	payload := map[string]interface{}{
+		"pow":             pow,
+		"instrumentation": instrumentation,
+		"metrics":         map[string]interface{}{"solver": map[string]interface{}{}},
+	}
+	pj, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, powCaptchaBaseURL+"/api/challenge/"+challengeID, bytes.NewReader(pj))
+	if err != nil {
+		return err
+	}
+	req.Header.Set(contentTypeHeaderKey, applicationJson)
+	req.Header.Set(acceptEncodingHeaderKey, gzipEncoding)
+	req = req.WithContext(ctx)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	by, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var result struct {
+		Status string `json:"status"`
+	}
+	_ = json.Unmarshal(by, &result)
+	if resp.StatusCode != http.StatusOK || result.Status != "solved" {
+		return fmt.Errorf("pow challenge verification failed (status %d): %s", resp.StatusCode, string(by))
+	}
+	return nil
+}
+
+// isPowCaptchaChallenge reports whether the challenge served by gameforge is a
+// proof-of-work captcha (gf-pow-captcha) rather than the image-drop captcha.
+func isPowCaptchaChallenge(ctx context.Context, client HttpClient, challengeID string) (bool, error) {
+	by, err := fetchURL(ctx, client, getChallengeURL(challengeBaseURL, challengeID))
+	if err != nil {
+		return false, err
+	}
+	var info struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(by, &info)
+	return info.Type == "gf-pow-captcha", nil
+}

--- a/pkg/wrapper/handlers.go
+++ b/pkg/wrapper/handlers.go
@@ -1651,7 +1651,7 @@ func GetCaptchaSolverHandler(c echo.Context) error {
 			bot.error(err)
 		}
 	}
-	return c.Redirect(http.StatusTemporaryRedirect, "/")
+	return c.JSON(http.StatusOK, SuccessResp(nil))
 }
 
 // CaptchaChallenge ...

--- a/pkg/wrapper/handlers.go
+++ b/pkg/wrapper/handlers.go
@@ -312,7 +312,10 @@ func CancelFleetHandler(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResp(400, err.Error()))
 	}
-	return c.JSON(http.StatusOK, SuccessResp(bot.CancelFleet(ogame.FleetID(fleetID))))
+	if err := bot.CancelFleet(ogame.FleetID(fleetID)); err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResp(500, err.Error()))
+	}
+	return c.JSON(http.StatusOK, SuccessResp(nil))
 }
 
 // GetAttacksHandler ...

--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -1629,6 +1629,20 @@ func (b *OGame) cancelFleet(fleetID ogame.FleetID) error {
 	if err != nil {
 		return err
 	}
+	if recallAction := page.GetDoc().Find("div#fleet"+utils.FI64(fleetID)+" a.icon_link").AttrOr("data-recall-action", ""); recallAction != "" {
+		// v13: recall via action=recallFleet&fleetId=&asJson=1
+		if _, err = b.getPageContent(url.Values{
+			"page":      {"ingame"},
+			"component": {"movement"},
+			"action":    {"recallFleet"},
+			"fleetId":   {fleetID.String()},
+			"asJson":    {"1"},
+			"token":     {token},
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
 	if _, err = b.getPageContent(url.Values{"page": {"ingame"}, "component": {"movement"}, "return": {fleetID.String()}, "token": {token}}); err != nil {
 		return err
 	}
@@ -2486,58 +2500,130 @@ func calcResources(price int64, planetResources ogame.PlanetResources, multiplie
 
 func (b *OGame) traderImportExportTrade(price int64, importToken string, planetResources ogame.PlanetResources, multiplier ogame.Multiplier) (string, error) {
 	payload := calcResources(price, planetResources, multiplier)
-	payload.Add("action", "trade")
 	payload.Add("bid[honor]", "0")
 	payload.Add("token", importToken)
-	payload.Add("ajax", "1")
-	pageHTML1, err := b.postPageContent(url.Values{"page": {"ajax"}, "component": {"traderimportexport"}, "ajax": {"1"}, "action": {"trade"}, "asJson": {"1"}}, payload)
+	var pageHTML1 []byte
+	var err error
+	if isOgameV13(b) {
+		payload.Add("action", "importExportTrade")
+		pageHTML1, err = b.postPageContent(url.Values{"page": {"ingame"}, "component": {"trader"}, "asJson": {"1"}}, payload)
+	} else {
+		payload.Add("action", "trade")
+		payload.Add("ajax", "1")
+		pageHTML1, err = b.postPageContent(url.Values{"page": {"ajax"}, "component": {"traderimportexport"}, "ajax": {"1"}, "action": {"trade"}, "asJson": {"1"}}, payload)
+	}
 	if err != nil {
 		return "", err
 	}
-	// {"message":"You have bought a container.","error":false,"item":{"uuid":"40f6c78e11be01ad3389b7dccd6ab8efa9347f3c","itemText":"You have purchased 1 KRAKEN Bronze.","bargainText":"The contents of the container not appeal to you? For 500 Dark Matter you can exchange the container for another random container of the same quality. You can only carry out this exchange 2 times per daily offer.","bargainCost":500,"bargainCostText":"Costs: 500 Dark Matter","tooltip":"KRAKEN Bronze|Reduces the building time of buildings currently under construction by <b>30m<\/b>.<br \/><br \/>\nDuration: now<br \/><br \/>\nPrice: --- <br \/>\nIn Inventory: 1","image":"98629d11293c9f2703592ed0314d99f320f45845","amount":1,"rarity":"common"},"newToken":"07eefc14105db0f30cb331a8b7af0bfe"}
+	// v12: {"message":"You have bought a container.","error":false,"item":{...},"newToken":"..."}
+	// v13: {"message":"...","success":true,"item":{...},"newAjaxToken":"..."} or {"message":"...","success":false,"errors":[{"message":"..."}]}
 	var result struct {
 		Message      string
-		Error        bool
+		Error        json.RawMessage
+		Errors       []struct {
+			Message string
+		}
 		NewAjaxToken string
 	}
 	if err := json.Unmarshal(pageHTML1, &result); err != nil {
 		return "", err
 	}
-	if result.Error {
+	if len(result.Error) > 0 && string(result.Error) != "false" && string(result.Error) != "null" {
 		return "", errors.New(result.Message)
+	}
+	if len(result.Errors) > 0 {
+		return "", errors.New(result.Errors[0].Message)
 	}
 	return result.NewAjaxToken, nil
 }
 
 func (b *OGame) traderImportExportTakeItem(token string) error {
-	payload := url.Values{"action": {"takeItem"}, "token": {token}, "ajax": {"1"}}
-	pageHTML, err := b.postPageContent(url.Values{"page": {"ajax"}, "component": {"traderimportexport"}, "ajax": {"1"}, "action": {"takeItem"}, "asJson": {"1"}}, payload)
+	var pageHTML []byte
+	var err error
+	if isOgameV13(b) {
+		pageHTML, err = b.postPageContent(
+			url.Values{"page": {"ingame"}, "component": {"trader"}, "asJson": {"1"}},
+			url.Values{"action": {"importExportTakeItem"}, "token": {token}},
+		)
+	} else {
+		pageHTML, err = b.postPageContent(
+			url.Values{"page": {"ajax"}, "component": {"traderimportexport"}, "ajax": {"1"}, "action": {"takeItem"}, "asJson": {"1"}},
+			url.Values{"action": {"takeItem"}, "token": {token}, "ajax": {"1"}},
+		)
+	}
 	if err != nil {
 		return err
 	}
 	var result struct {
 		Message      string
-		Error        bool
+		Error        json.RawMessage
+		Errors       []struct {
+			Message string
+		}
 		NewAjaxToken string
 	}
 	if err := json.Unmarshal(pageHTML, &result); err != nil {
 		return err
 	}
-	if result.Error {
+	if len(result.Error) > 0 && string(result.Error) != "false" && string(result.Error) != "null" {
 		return errors.New(result.Message)
 	}
-	// {"error":false,"message":"You have accepted the offer and put the item in your inventory.","item":{"name":"Bronze Deuterium Booster","image":"f0e514af79d0808e334e9b6b695bf864b861bdfa","imageLarge":"c7c2837a0b341d37383d6a9d8f8986f500db7bf9","title":"Bronze Deuterium Booster|+10% more Deuterium Synthesizer harvest on one planet<br \/><br \/>\nDuration: 1w<br \/><br \/>\nPrice: --- <br \/>\nIn Inventory: 134","effect":"+10% more Deuterium Synthesizer harvest on one planet","ref":"d9fa5f359e80ff4f4c97545d07c66dbadab1d1be","rarity":"common","amount":134,"amount_free":134,"amount_bought":0,"category":["d8d49c315fa620d9c7f1f19963970dea59a0e3be","e71139e15ee5b6f472e2c68a97aa4bae9c80e9da"],"currency":"dm","costs":"2500","isReduced":false,"buyable":false,"canBeActivated":true,"canBeBoughtAndActivated":false,"isAnUpgrade":false,"isCharacterClassItem":false,"hasEnoughCurrency":true,"cooldown":0,"duration":604800,"durationExtension":null,"totalTime":null,"timeLeft":null,"status":null,"extendable":false,"firstStatus":"effecting","toolTip":"Bronze Deuterium Booster|+10% more Deuterium Synthesizer harvest on one planet&lt;br \/&gt;&lt;br \/&gt;\nDuration: 1w&lt;br \/&gt;&lt;br \/&gt;\nPrice: --- &lt;br \/&gt;\nIn Inventory: 134","buyTitle":"This item is currently unavailable for purchase.","activationTitle":"Activate","moonOnlyItem":false,"newOffer":false,"noOfferMessage":"There are no further offers today. Please come again tomorrow."},"newToken":"dec779714b893be9b39c0bedf5738450","components":[],"newAjaxToken":"e20cf0a6ca0e9b43a81ccb8fe7e7e2e3"}
+	if len(result.Errors) > 0 {
+		return errors.New(result.Errors[0].Message)
+	}
+	// v12: {"error":false,"message":"You have accepted the offer and put the item in your inventory.","item":{...},"newToken":"..."}
+	// v13: {"message":"...","success":true,"item":{...},"newAjaxToken":"..."}
 	return nil
 }
 
 func (b *OGame) buyOfferOfTheDay() error {
-	pageHTML, err := b.postPageContent(url.Values{"page": {"ajax"}, "component": {"traderimportexport"}}, url.Values{"show": {"importexport"}, "ajax": {"1"}})
-	if err != nil {
-		return err
+	var pageHTML []byte
+	var err error
+	v13ImportToken := ""
+	if isOgameV13(b) {
+		// Load the trader page to grab the csrf token used to fetch the import/export view.
+		traderPage, err := b.getPageContent(url.Values{"page": {"ingame"}, "component": {"trader"}})
+		if err != nil {
+			return err
+		}
+		tokenMatch := regexp.MustCompile(`var token\s?=\s?"([^"]+)"`).FindStringSubmatch(string(traderPage))
+		if len(tokenMatch) != 2 {
+			tokenMatch = regexp.MustCompile(`token\s?=\s?"([^"]+)"`).FindStringSubmatch(string(traderPage))
+		}
+		if len(tokenMatch) != 2 {
+			return errors.New("failed to extract trader token")
+		}
+		pageHTML, err = b.postPageContent(
+			url.Values{"page": {"ingame"}, "component": {"trader"}, "action": {"importexport"}, "ajax": {"1"}},
+			url.Values{"action": {"importexport"}, "token": {tokenMatch[1]}, "ajax": {"1"}},
+		)
+		if err != nil {
+			return err
+		}
+		// v13 wraps the import/export page in a JSON envelope: {"content":{"trader":"<html>"},"newAjaxToken":"..."}
+		var importExportResp struct {
+			Content struct {
+				Trader string `json:"trader"`
+			} `json:"content"`
+			NewAjaxToken string `json:"newAjaxToken"`
+		}
+		if err = json.Unmarshal(pageHTML, &importExportResp); err != nil {
+			return err
+		}
+		pageHTML = []byte(importExportResp.Content.Trader)
+		v13ImportToken = importExportResp.NewAjaxToken
+	} else {
+		pageHTML, err = b.postPageContent(url.Values{"page": {"ajax"}, "component": {"traderimportexport"}}, url.Values{"show": {"importexport"}, "ajax": {"1"}})
+		if err != nil {
+			return err
+		}
 	}
 	price, importToken, planetResources, multiplier, err := b.extractor.ExtractOfferOfTheDay(pageHTML)
 	if err != nil {
 		return err
+	}
+	if isOgameV13(b) && v13ImportToken != "" {
+		importToken = v13ImportToken
 	}
 	newAjaxToken, err := b.traderImportExportTrade(price, importToken, planetResources, multiplier)
 	if err != nil {
@@ -2564,14 +2650,38 @@ func fixAttackEvents(attacks []ogame.AttackEvent, planets []Planet) {
 }
 
 func (b *OGame) getAttacks(opts ...Option) (out []ogame.AttackEvent, err error) {
-	vals := url.Values{"page": {"componentOnly"}, "component": {EventListAjaxPageName}, "ajax": {"1"}}
-	page, err := getAjaxPage[parser.EventListAjaxPage](b, vals, opts...)
-	if err != nil {
-		return
+	var pageHTML []byte
+	if isOgameV13(b) {
+		// v13 loads the event list via a JSON endpoint and wraps the html in content.eventlist
+		var by []byte
+		if by, err = b.getPageContent(url.Values{"page": {"ingame"}, "component": {"eventlist"}, "action": {"catchEvents"}, "ajax": {"1"}}); err != nil {
+			return
+		}
+		var eventResp struct {
+			Content struct {
+				Eventlist string `json:"eventlist"`
+			} `json:"content"`
+		}
+		if err = json.Unmarshal(by, &eventResp); err != nil {
+			return
+		}
+		pageHTML = []byte(eventResp.Content.Eventlist)
+	} else {
+		vals := url.Values{"page": {"componentOnly"}, "component": {EventListAjaxPageName}, "ajax": {"1"}}
+		var page parser.EventListAjaxPage
+		page, err = getAjaxPage[parser.EventListAjaxPage](b, vals, opts...)
+		if err != nil {
+			return
+		}
+		pageHTML = page.GetContent()
 	}
 	planets := b.getCachedPlanets()
 	ownCoords := getOwnCoordinates(planets)
-	out, err = page.ExtractAttacks(ownCoords)
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(pageHTML))
+	if err != nil {
+		return
+	}
+	out, err = b.extractor.ExtractAttacksFromDoc(doc, ownCoords)
 	if err != nil {
 		return
 	}

--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -2603,6 +2603,9 @@ func (b *OGame) galaxyInfos(galaxy, system int64, opts ...Option) (ogame.SystemI
 		"system": {utils.FI64(system)},
 	}
 	vals := url.Values{"page": {"ingame"}, "component": {"galaxy"}, "action": {"fetchGalaxyContent"}, "ajax": {"1"}, "asJson": {"1"}}
+	if ogVersion, err := version.NewVersion(sanitizeServerVersion(b.cache.serverData.Version)); err == nil && isVGreaterThanOrEqual(ogVersion, "13.0.0") {
+		vals = url.Values{"page": {"ingame"}, "component": {"galaxy"}, "action": {"fetchSolarSystemData"}, "asJson": {"1"}}
+	}
 	pageHTML, err := b.postPageContent(vals, payload, opts...)
 	if err != nil {
 		return res, err
@@ -2622,6 +2625,26 @@ func (b *OGame) galaxyInfos(galaxy, system int64, opts ...Option) (ogame.SystemI
 }
 
 func (b *OGame) getGalaxyPage(galaxy int64, system int64, opts ...Option) (*GalaxyPageContent, error) {
+	if ogVersion, err := version.NewVersion(sanitizeServerVersion(b.cache.serverData.Version)); err == nil && isVGreaterThanOrEqual(ogVersion, "13.0.0") {
+		by, err := b.postPageContent(url.Values{
+			"page":      {"ingame"},
+			"component": {"galaxy"},
+			"action":    {"fetchSolarSystemData"},
+			"asJson":    {"1"},
+		}, url.Values{
+			"galaxy": {strconv.Itoa(int(galaxy))},
+			"system": {strconv.Itoa(int(system))},
+		}, opts...)
+		if err != nil {
+			return nil, err
+		}
+		var res GalaxyPageContent
+		if err = json.Unmarshal(by, &res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+
 	// Get galaxy page content for the desired system.
 	by, err := b.postPageContent(url.Values{
 		"page":      {"ingame"},

--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -3303,6 +3303,7 @@ type CheckTargetResponse struct {
 	} `json:"targetPlanet"`
 	Errors          []OGameError `json:"errors"`
 	TargetOk        bool         `json:"targetOk"`
+	Message         string       `json:"message"`
 	Components      []any        `json:"components"`
 	EmptySystems    int64        `json:"emptySystems"`
 	InactiveSystems int64        `json:"inactiveSystems"`
@@ -3450,9 +3451,13 @@ func (b *OGame) sendFleet(celestialID ogame.CelestialID, ships ogame.ShipsInfos,
 		return zeroFleet, err
 	}
 
-	if !checkRes.TargetOk {
-		if len(checkRes.Errors) > 0 {
-			return zeroFleet, errors.New(checkRes.Errors[0].Message + " (" + strconv.Itoa(checkRes.Errors[0].Error) + ")")
+	targetAccepted := checkRes.TargetOk || (checkRes.Status == "success" && strings.EqualFold(strings.TrimSpace(checkRes.Message), "ok"))
+	if !targetAccepted {
+		if len(checkRes.Errors) > 0 && strings.TrimSpace(checkRes.Errors[0].Message) != "" {
+			return zeroFleet, fmt.Errorf("%s (%d)", checkRes.Errors[0].Message, checkRes.Errors[0].Error)
+		}
+		if message := strings.TrimSpace(checkRes.Message); message != "" && !strings.EqualFold(message, "ok") {
+			return zeroFleet, errors.New(message)
 		}
 		return zeroFleet, errors.New("target is not ok")
 	}

--- a/pkg/wrapper/ogame_login.go
+++ b/pkg/wrapper/ogame_login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alaingilbert/ogame/pkg/extractor/v11_15_0"
 	"github.com/alaingilbert/ogame/pkg/extractor/v11_9_0"
 	"github.com/alaingilbert/ogame/pkg/extractor/v12_0_0"
+	"github.com/alaingilbert/ogame/pkg/extractor/v13_0_0"
 	v7 "github.com/alaingilbert/ogame/pkg/extractor/v7"
 	v71 "github.com/alaingilbert/ogame/pkg/extractor/v71"
 	v8 "github.com/alaingilbert/ogame/pkg/extractor/v8"
@@ -276,8 +277,17 @@ func isVGreaterThanOrEqual(v *version.Version, compareVersion string) bool {
 	return v.GreaterThanOrEqual(version.Must(version.NewVersion(compareVersion)))
 }
 
+func isOgameV13(b *OGame) bool {
+	if ogVersion, err := version.NewVersion(sanitizeServerVersion(b.cache.serverData.Version)); err == nil {
+		return isVGreaterThanOrEqual(ogVersion, "13.0.0")
+	}
+	return false
+}
+
 func getExtractorFor(ogVersion *version.Version) (ext extractor.Extractor) {
-	if isVGreaterThanOrEqual(ogVersion, "12.0.0") {
+	if isVGreaterThanOrEqual(ogVersion, "13.0.0") {
+		ext = v13_0_0.NewExtractor()
+	} else if isVGreaterThanOrEqual(ogVersion, "12.0.0") {
 		ext = v12_0_0.NewExtractor()
 	} else if isVGreaterThanOrEqual(ogVersion, "11.15.0") {
 		ext = v11_15_0.NewExtractor()


### PR DESCRIPTION
Updates OGame v13 galaxy and discovery requests to use fetchSolarSystemData, preserves the legacy path for pre-v13 servers, accepts successful checkTarget message responses, propagates detailed fleet validation errors, and parses the renamed v13 lifeform bonus categories. Tests: go test ./pkg/wrapper; targeted v12/v13 lifeform parser tests. Live validation on Xanthippe-pt 13.0.0-r8: galaxy lookup, discovery mission 18, expedition, 15 ship bonus entries, 17 cost/time entries, and the 2.23% expedition resource bonus were returned successfully.